### PR TITLE
Update Editor.js

### DIFF
--- a/src/Editor.js
+++ b/src/Editor.js
@@ -212,8 +212,8 @@ export default class Editor extends React.Component<Props> {
           return Promise.resolve({
             getControl: () => editor,
           });
-        }),
-      },
+        }
+      }),
     });
 
     Object.keys(this.props.files).forEach(path =>


### PR DESCRIPTION
Error on npm run start 

ERROR in ./src/Editor.js
Module build failed (from ./node_modules/babel-loader/lib/index.js):
SyntaxError: D:/Wagner/MLS/SrcMonacoEditor/src/Editor.js: Unexpected token, expected , (215:9)